### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,6 @@
 name: Build and Test
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/Xieons-Gaming-Corner/Tera-Finder/security/code-scanning/4](https://github.com/Xieons-Gaming-Corner/Tera-Finder/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the least privileges required for the workflow. Since the workflow primarily involves reading repository contents and uploading artifacts, the `contents: read` permission is sufficient. This ensures that the workflow does not inadvertently gain write access to the repository.

The `permissions` block should be added at the top level of the workflow file, right after the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
