### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Xieons-Gaming-Corner/Tera-Finder/security/code-scanning/2](https://github.com/Xieons-Gaming-Corner/Tera-Finder/security/code-scanning/2)

To fix the issue, we need to explicitly define a `permissions` block within the workflow file to restrict the permissions of the `GITHUB_TOKEN`. Based on the workflow's actions, it appears that it primarily reads repository contents and uploads artifacts. Therefore, the minimal permissions required for this job are `contents: read`. If future jobs or steps require additional permissions, they can be added incrementally.

The following changes should be made:
1. Add a `permissions` key at the root level of the workflow file, applied to all jobs. This ensures that all jobs in the workflow inherit the least privilege permissions unless explicitly overridden.
2. Set `contents: read` as the permission to limit the scope of the `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
