### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,6 @@
 name: .NET Desktop
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Xieons-Gaming-Corner/Tera-Finder/security/code-scanning/5](https://github.com/Xieons-Gaming-Corner/Tera-Finder/security/code-scanning/5)

To address the issue, add an explicit `permissions` block at the start of the workflow (before `jobs:`), which restricts the GITHUB_TOKEN used by the workflow to only the privileges needed. In most cases—such as this workflow which checks out code and uploads artifacts—only `contents: read` is required and recommended as a minimal starting point. This change should be applied at the top level of the workflow, affecting all jobs, unless specific jobs require additional permissions.  
**Required changes:**  
- Add a `permissions:` block below the workflow `name:`/before `on:` containing `contents: read`.  
No additional methods, imports, or definitions are necessary.  

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to grant read-only access to repository contents for automation tokens, aligning with least-privilege best practices and improving security.
  * No impact on application features, performance, or release process; build and test steps remain unchanged.
  * Helps prevent unintended writes from CI while maintaining necessary visibility into the repository during runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->